### PR TITLE
Fixes missing routes

### DIFF
--- a/pyroute2/ipdb/routes.py
+++ b/pyroute2/ipdb/routes.py
@@ -148,7 +148,8 @@ RouteKey = namedtuple('RouteKey',
                        'table',
                        'family',
                        'priority',
-                       'tos'))
+                       'tos',
+                       'oif'))
 
 # IP multipath NH key
 IPNHKey = namedtuple('IPNHKey',


### PR DESCRIPTION
routes with similar prefix/gateway on different interfaces are missing due to lack of properties in the route-key
this mini-fix fixes it.